### PR TITLE
Added more instances, subnets and SG to infrastructure

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,63 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.49.0"
+  constraints = ">= 3.73.0"
+  hashes = [
+    "h1:HxPUxrHpAJey832OwVk3J2T7lHpRzMavqjXDzaFyM6I=",
+    "zh:09803937f00fdf2873eccf685eec7854408925cbf183c9b683df7c5825be463f",
+    "zh:2af1575e538fb0b669266f8d1385b17bfdaf17c521b6b6329baa1f2971fc4a4d",
+    "zh:3f71882b438cde3108fe68cfe2637839d3eed08157a9721bd97babf3912247a8",
+    "zh:577af1b38f5da8a9f29eebe5eebec9279d26e757cd03b0c8c59311f9ce8a859b",
+    "zh:60160d39094973beefb9b10cfd6aaa5b63a2e68c32445ecffcd1b101356e6f9b",
+    "zh:762656454722548baeccf35cbaa23b887976337e1ed321682df7390419fdf22d",
+    "zh:7f6d7887821659bf3bef815949077dc91ffcdb0d911644a887b6683b264a5ca6",
+    "zh:8f16a352cc903f8951fa4619c36233b3e66e27d724817b131f2035dd8896f524",
+    "zh:8f768f65e370366c8b91c00d01c9a6264fe26ea9ae1819f14bdcd12c066272bc",
+    "zh:95ad78c689a83c08ef7c3e544c3c9aca93ed528054aa77cc968ddd9efa3a1023",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a47097ab6a4ca8302da82964303ffdd2310ed65e8f8524bfe4058816cf1addb7",
+    "zh:b66d820c70cd5fd628ffe882d2b97e76b969dca4e6827ac2ba0f8d3bc5d6e9c6",
+    "zh:b80f713a4f3e1355c3dd1600e9d08b9f15ed2370054ec792ad2c01f2541abe02",
+    "zh:ce065bc3962cb71fa7652562226b9d486f3d7fcb88285c1020ebe2f550e28641",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.2.3"
+  hashes = [
+    "h1:3bH88Z7tlWvcoubm6hQUBk3s9bSIJC8bVHQz749B87E=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.0.4"
+  hashes = [
+    "h1:rKKMyIEBZwR+8j6Tx3PwqBrStuH+J+pxcbCR5XN8WAw=",
+    "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
+    "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
+    "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",
+    "zh:5a8eec2409a9ff7cd0758a9d818c74bcba92a240e6c5e54b99df68fff312bbd5",
+    "zh:5e6a4b39f3171f53292ab88058a59e64825f2b842760a4869e64dc1dc093d1fe",
+    "zh:810547d0bf9311d21c81cc306126d3547e7bd3f194fc295836acf164b9f8424e",
+    "zh:824a5f3617624243bed0259d7dd37d76017097dc3193dac669be342b90b2ab48",
+    "zh:9361ccc7048be5dcbc2fafe2d8216939765b3160bd52734f7a9fd917a39ecbd8",
+    "zh:aa02ea625aaf672e649296bce7580f62d724268189fe9ad7c1b36bb0fa12fa60",
+    "zh:c71b4cd40d6ec7815dfeefd57d88bc592c0c42f5e5858dcc88245d371b4b8b1e",
+    "zh:dabcd52f36b43d250a3d71ad7abfa07b5622c69068d989e60b79b2bb4f220316",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -9,11 +9,13 @@ module "ssh-key" {
 }
 
 module "ec2" {
-  source     = "./modules/ec2"
-  namespace  = var.namespace
-  vpc        = module.networking.vpc
-  sg_pub_id  = module.networking.sg_pub_id
-  sg_priv_id = module.networking.sg_priv_id
-  key_name   = module.ssh-key.key_name
+  source          = "./modules/ec2"
+  namespace       = var.namespace
+  vpc             = module.networking.vpc
+  sg_pub_id       = module.networking.sg_pub_id
+  sg_priv_id      = module.networking.sg_priv_id
+  sg_db_access_id = module.networking.sg_db_access_id
+  web_sg_id       = module.networking.web_sg_id
+  key_name        = module.ssh-key.key_name
 }
 

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -17,7 +17,7 @@ resource "aws_instance" "jumpbox" {
   associate_public_ip_address = true
   instance_type               = var.instance_type
   key_name                    = var.key_name
-  subnet_id                   = var.vpc.public_subnets[0]
+  subnet_id                   = var.vpc.public_subnets[2]
   vpc_security_group_ids      = [var.sg_pub_id]
 
   tags = {
@@ -60,6 +60,19 @@ resource "aws_instance" "ec2_private" {
   key_name                    = var.key_name
   subnet_id                   = var.vpc.private_subnets[1]
   vpc_security_group_ids      = [var.sg_priv_id]
+  tags = {
+    "Name" = "${var.namespace}-app"
+  } 
+} 
+
+// Configure web_server EC2 instance
+resource "aws_instance" "web_server" {
+  ami                         = data.aws_ami.amazon-linux-2.id
+  associate_public_ip_address = true
+  instance_type               = var.instance_type
+  key_name                    = var.key_name
+  subnet_id                   = var.vpc.private_subnets[0]
+  vpc_security_group_ids      = [var.web_sg_id]
   user_data = <<-EOF
     #!/bin/bash
     sudo yum update -y
@@ -69,7 +82,21 @@ resource "aws_instance" "ec2_private" {
     echo "<html><body><div>Hello, world!</div></body></html>" > /var/www/html/index.html
     EOF
   tags = {
-    "Name" = "${var.namespace}-node"
+    "Name" = "${var.namespace}-web_server"
+  }  
+
+}
+
+// Configure database subnet
+resource "aws_instance" "db_server" {
+  ami                         = data.aws_ami.amazon-linux-2.id
+  associate_public_ip_address = false
+  instance_type               = var.instance_type
+  key_name                    = var.key_name
+  subnet_id                   = var.vpc.private_subnets[0]
+  vpc_security_group_ids      = [var.sg_db_access_id]
+  tags = {
+    "Name" = "${var.namespace}-db_server"
   }  
 
 }

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -6,3 +6,13 @@ output "private_ip" {
  value = aws_instance.ec2_private.private_ip
   // value = aws_instance.ec2_private.*.private_ip
 }
+
+output "web_server_public_ip" {
+ value = aws_instance.web_server.public_ip
+  // value = aws_instance.ec2_private.*.private_ip
+}
+
+output "db_server_private_ip" {
+ value = aws_instance.db_server.private_ip
+  // value = aws_instance.ec2_private.*.private_ip
+}

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -18,6 +18,14 @@ variable "sg_priv_id" {
   type = any
 }
 
+variable "sg_db_access_id" {
+  type = any
+}
+
+variable "web_sg_id" {
+  type = any
+}
+
 variable "instance_type" {
   description = "AWS Instance Types"
   default     = "t2.micro"

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -7,9 +7,10 @@ module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
   name                             = "${var.namespace}-vpc"
   cidr                             = "192.168.0.0/16"
-  azs                              = ["${local.region}a", "${local.region}b"]
-  private_subnets                  = ["192.168.0.0/24", "192.168.1.0/24"]
-  public_subnets                   = ["192.168.2.0/24", "192.168.3.0/24"]
+  azs                              = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  private_subnets                  = ["192.168.0.0/24", "192.168.1.0/24", "192.168.2.0/24"]
+  public_subnets                   = ["192.168.3.0/24", "192.168.4.0/24", "192.168.5.0/24"]
+  database_subnets                 = ["192.168.6.0/24", "192.168.7.0/24", "192.168.8.0/24"]
   #assign_generated_ipv6_cidr_block = true
   create_database_subnet_group     = false
   enable_nat_gateway               = true
@@ -42,6 +43,74 @@ resource "aws_security_group" "allow_ssh_pub" {
   }
 }
 
+// SG to allow SSH connections to webserices from outside. for security purposes replace 0.0.0.0/0 to a secured IP
+resource "aws_security_group" "web_sg" {
+  name        = "${var.namespace}-web_sg"
+  description = "Allow web inbound traffic from the internet"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "web traffic from the internet"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "ssh from jumpbox"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["192.168.5.0/24"]
+  }
+
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.namespace}-web_sg"
+  }
+}
+// SG to allow db connections to database from private subnet. for security purposes replace 0.0.0.0/0 to a secured IP
+resource "aws_security_group" "db_access" {
+  name        = "${var.namespace}-db_access"
+  description = "Allow database connection within private subnet"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "allow database access"
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = ["192.168.0.0/24"]
+  }
+
+  ingress {
+    description = "allow ssh access from jumpbox"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["192.168.5.0/24"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.namespace}-db_access_sg"
+  }
+}
+
 // Security Group to only allow SSH connections from VPC private subnets
 resource "aws_security_group" "allow_ssh_priv" {
   name        = "${var.namespace}-allow_ssh_priv"
@@ -53,7 +122,14 @@ resource "aws_security_group" "allow_ssh_priv" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["192.168.0.0/16"]
+    cidr_blocks = ["192.168.5.0/24"]
+  }
+  ingress {
+    description = "connection from web_server"
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["192.168.0.0/24"]
   }
 
   egress {

--- a/modules/networking/output.tf
+++ b/modules/networking/output.tf
@@ -9,3 +9,11 @@ output "sg_pub_id" {
 output "sg_priv_id" {
   value = aws_security_group.allow_ssh_priv.id
 }
+
+output "sg_db_access_id" {
+  value = aws_security_group.db_access.id
+}
+
+output "web_sg_id" {
+  value = aws_security_group.web_sg.id
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = var.region
+  region     = var.region
   access_key = var.access_key
   secret_key = var.secret_key
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "namespace" {
   description = "The project namespace to use for unique resource naming"
-  default     = "allamerica-challenge"
+  default     = "charity-terraform-project"
   type        = string
 }
 
@@ -12,12 +12,12 @@ variable "region" {
 
 variable "access_key" {
   description = "AWS Access Key"
-  default     = "enter your aws access key"
+  default     = "put your access key here"
   type        = string
 }
 
 variable "secret_key" {
   description = "AWS Secret Key"
-  default     = "enter your aws secret key"
+  default     = "put your secret here"
   type        = string
 }


### PR DESCRIPTION
This is a terraform code that provision the following
 -  3 private subnets in three different availability zones 
 - 4 ec2 t2. micro Instances allocated to each of the zones.
    Of The Four Instances,
 - The web sever is on the public subnet and can be open via port 80. 
 - the web sever allow incoming trafic from the CIDR of the jumpbox on port 22 and is on availability zone "a"
 - A jump box on the public subnet acessable from my home IP address and placed on availability zone "c"
 - An application sever used as the back-end on a private subnet and can be accessable from CIDR where the web sever is located on port 8080 and the CIDR from where the jumpbox is located on port 22.
 - A database Instance that MySQL will be install later and will be placed on the database subnet precisely on availability zone "b" wich is allowing incoming traffic only from application server on port 3306 and the jumpbox on port 22. 
 - This code will generate an ssh-key and the key will be downloaded on the terraform workspace which will late be copied to the jumpbox ec2-user home directory by a provisioner. This ssh-key will be used to access each of the instance 



